### PR TITLE
Make some improvement for MCBinaryHeap

### DIFF
--- a/MCBinaryHeap/MCBinaryHeap.h
+++ b/MCBinaryHeap/MCBinaryHeap.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol MCBinaryHeapObject <NSObject>
-- (NSComparisonResult)compare:(id)otherObject;
+- (NSComparisonResult)heap_compare:(id<MCBinaryHeapObject>)otherObject;
 @end
 
 @interface MCBinaryHeap : NSObject <NSCopying>

--- a/MCBinaryHeap/MCBinaryHeap.m
+++ b/MCBinaryHeap/MCBinaryHeap.m
@@ -17,7 +17,15 @@ static void heap_release(CFAllocatorRef all, const void *ptr) {
 }
 
 static CFComparisonResult heap_compare(const void *ptr1, const void *ptr2, void *info) {
-	return (CFComparisonResult)[(__bridge id)ptr1 compare:(__bridge id)ptr2];
+    id left = (__bridge id)ptr1;
+    id right = (__bridge id)ptr2;
+    if ([left conformsToProtocol:@protocol(MCBinaryHeapObject)] &&
+        [right conformsToProtocol:@protocol(MCBinaryHeapObject)])
+    {
+        return (CFComparisonResult)[(id<MCBinaryHeapObject>)left heap_compare:(id<MCBinaryHeapObject>)right];
+    } else {
+        return (CFComparisonResult)[left compare:right];
+    }
 }
 
 static void heap_apply(const void *val, void *context) {


### PR DESCRIPTION
The -[compare:] method in the protocol to be implemented is also a standard method for every OC object. So I don't think making a duplicate declaration in the heap protocol is a good idea. Your code is great, which solves my problem. And I make some improvement in it, hoping to be merged into your repo.